### PR TITLE
updated the CHANGELOG and version to release binary packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,22 @@
 - http://wiki.ros.org/open_manipulator (metapackage)
 - http://wiki.ros.org/open_manipulator_description
 - http://wiki.ros.org/open_manipulator_dynamixel_ctrl
-- http://wiki.ros.org/open_manipulator_gazebo
 - http://wiki.ros.org/open_manipulator_moveit
-- http://wiki.ros.org/open_manipulator_msgs
 - http://wiki.ros.org/open_manipulator_position_ctrl
-- http://wiki.ros.org/open_manipulator_with_tb3
 
 ## Open Source related to OpenManipulator
 - [open_manipulator](https://github.com/ROBOTIS-GIT/open_manipulator)
+- [open_manipulator_msgs](https://github.com/ROBOTIS-GIT/open_manipulator_msgs)
+- [open_manipulator_simulations](https://github.com/ROBOTIS-GIT/open_manipulator_simulations)
+- [open_manipulator_perceptions](https://github.com/ROBOTIS-GIT/open_manipulator_perceptions)
+- [open_manipulator_with_tb3](https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3)
+- [open_manipulator_with_tb3_msgs](https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3_msgs)
+- [open_manipulator_with_tb3_simulations](https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3_simulations)
 - [turtlebot3](https://github.com/ROBOTIS-GIT/turtlebot3)
 - [turtlebot3_msgs](https://github.com/ROBOTIS-GIT/turtlebot3_msgs)
 - [turtlebot3_simulations](https://github.com/ROBOTIS-GIT/turtlebot3_simulations)
 - [turtlebot3_applications](https://github.com/ROBOTIS-GIT/turtlebot3_applications)
+- [turtlebot3_applications_msgs](https://github.com/ROBOTIS-GIT/turtlebot3_applications_msgs)
 - [turtlebot3_autorace](https://github.com/ROBOTIS-GIT/turtlebot3_autorace)
 - [turtlebot3_deliver](https://github.com/ROBOTIS-GIT/turtlebot3_deliver)
 - [hls_lfcd_lds_driver](https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver)

--- a/open_manipulator/CHANGELOG.rst
+++ b/open_manipulator/CHANGELOG.rst
@@ -2,6 +2,22 @@
 Changelog for package open_manipulator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+1.0.0 (2018-06-01)
+------------------
+* package reconfiguration for OpenManipulator
+* added new stl files
+* added urdf, rviz param, gazebo params, group
+* added function to support protocol 1.0
+* modified color, xacro server, mu1, mu2, collision range, joint limit
+* modified joint_state_publisher, joint_states_publisher
+* modified params of inertial, xacro, gazebo, collision, friction 
+* modified urdf file names and collision geometry
+* modified motor id, msg names
+* modified description and package tree
+* deleted unnecessary packages
+* merged pull request `#34 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/34>`_ `#33 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/33>`_ `#32 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/32>`_ `#31 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/31>`_ `#27 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/27>`_ `#26 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/26>`_ `#25 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/25>`_
+* Contributors: Darby Lim, Pyo
+
 0.1.1 (2018-03-15)
 ------------------
 * modified build setting for using yaml-cpp

--- a/open_manipulator/package.xml
+++ b/open_manipulator/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>open_manipulator</name>
-  <version>0.1.1</version>
+  <version>1.0.0</version>
   <description>
     ROS-enabled OpenManipulator is a full open robot platform consisting of OpenSoftware​, OpenHardware and OpenCR(Embedded board)​.
     The OpenManipulator is allowed users to control it more easily by linking with the MoveIt! package. Moreover it has full hardware compatibility with TurtleBot3​. 
@@ -10,9 +10,10 @@
   <license>Apache 2.0</license>
   <author email="thlim@robotis.com">Darby Lim</author>
   <maintainer email="pyo@robotis.com">Pyo</maintainer>
-  <url type="bugtracker">https://github.com/ROBOTIS-GIT/open_manipulator/issues</url>
+  <url type="website">http://wiki.ros.org/open_manipulator</url>
+  <url type="emanual">http://emanual.robotis.com/docs/en/platform/openmanipulator</url>
   <url type="repository">https://github.com/ROBOTIS-GIT/open_manipulator</url>
-  <url type="website">http://emanual.robotis.com/docs/en/platform/openmanipulator</url>
+  <url type="bugtracker">https://github.com/ROBOTIS-GIT/open_manipulator/issues</url>
   <buildtool_depend>catkin</buildtool_depend>
   <exec_depend>open_manipulator_description</exec_depend>
   <exec_depend>open_manipulator_dynamixel_ctrl</exec_depend>

--- a/open_manipulator_description/CHANGELOG.rst
+++ b/open_manipulator_description/CHANGELOG.rst
@@ -2,6 +2,19 @@
 Changelog for package open_manipulator_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+1.0.0 (2018-06-01)
+------------------
+* package reconfiguration for OpenManipulator
+* added new stl files
+* added urdf, rviz param, gazebo params, group
+* modified color, xacro server, mu1, mu2, collision range, joint limit
+* modified joint_state_publisher, joint_states_publisher
+* modified params of inertial, xacro, gazebo, collision, friction 
+* modified urdf file names and collision geometry
+* deleted unnecessary packages
+* merged pull request `#34 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/34>`_ `#33 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/33>`_ `#31 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/31>`_ `#27 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/27>`_ `#26 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/26>`_ `#25 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/25>`_
+* Contributors: Darby Lim, Pyo
+
 0.1.1 (2018-03-15)
 ------------------
 * none

--- a/open_manipulator_description/CMakeLists.txt
+++ b/open_manipulator_description/CMakeLists.txt
@@ -1,13 +1,17 @@
 ################################################################################
-# CMake
+# Set minimum required version of cmake, project name and compile options
 ################################################################################
 cmake_minimum_required(VERSION 2.8.3)
 project(open_manipulator_description)
 
 ################################################################################
-# Packages
+# Find catkin packages and libraries for catkin and system dependencies
 ################################################################################
 find_package(catkin REQUIRED)
+
+################################################################################
+# Setup for python modules and scripts
+################################################################################
 
 ################################################################################
 # Declare ROS messages, services and actions
@@ -18,7 +22,7 @@ find_package(catkin REQUIRED)
 ################################################################################
 
 ################################################################################
-# Catkin specific configuration
+# Declare catkin specific configuration to be passed to dependent projects
 ################################################################################
 catkin_package()
 

--- a/open_manipulator_description/package.xml
+++ b/open_manipulator_description/package.xml
@@ -1,16 +1,17 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>open_manipulator_description</name>
-  <version>0.1.1</version>
+  <version>1.0.0</version>
   <description>
     OpenManipulator 3D model description for visualization and simulation 
   </description>
   <license>Apache 2.0</license>
   <author email="thlim@robotis.com">Darby Lim</author>
   <maintainer email="pyo@robotis.com">Pyo</maintainer>
-  <url type="bugtracker">https://github.com/ROBOTIS-GIT/open_manipulator/issues</url>
+  <url type="website">http://wiki.ros.org/open_manipulator_description</url>
+  <url type="emanual">http://emanual.robotis.com/docs/en/platform/openmanipulator</url>
   <url type="repository">https://github.com/ROBOTIS-GIT/open_manipulator</url>
-  <url type="website">http://emanual.robotis.com/docs/en/platform/openmanipulator</url>
+  <url type="bugtracker">https://github.com/ROBOTIS-GIT/open_manipulator/issues</url>
   <buildtool_depend>catkin</buildtool_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/open_manipulator_dynamixel_ctrl/CHANGELOG.rst
+++ b/open_manipulator_dynamixel_ctrl/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package open_manipulator_dynamixel_ctrl
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+1.0.0 (2018-06-01)
+------------------
+* package reconfiguration for OpenManipulator
+* added function to support protocol 1.0
+* modified motor id, msg names
+* merged pull request `#34 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/34>`_ `#33 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/33>`_ `#31 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/31>`_ `#27 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/27>`_ `#26 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/26>`_ `#25 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/25>`_
+* Contributors: Darby Lim, Pyo
+
 0.1.1 (2018-03-15)
 ------------------
 * none

--- a/open_manipulator_dynamixel_ctrl/CMakeLists.txt
+++ b/open_manipulator_dynamixel_ctrl/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# CMake
+# Set minimum required version of cmake, project name and compile options
 ################################################################################
 cmake_minimum_required(VERSION 2.8.3)
 project(open_manipulator_dynamixel_ctrl)
@@ -7,7 +7,7 @@ project(open_manipulator_dynamixel_ctrl)
 add_compile_options(-std=c++11)
 
 ################################################################################
-# Packages
+# Find catkin packages and libraries for catkin and system dependencies
 ################################################################################
 find_package(catkin REQUIRED COMPONENTS
   roscpp
@@ -15,6 +15,10 @@ find_package(catkin REQUIRED COMPONENTS
   dynamixel_sdk
   dynamixel_workbench_toolbox
 )
+
+################################################################################
+# Setup for python modules and scripts
+################################################################################
 
 ################################################################################
 # Declare ROS messages, services and actions
@@ -25,7 +29,7 @@ find_package(catkin REQUIRED COMPONENTS
 ################################################################################
 
 ################################################################################
-# Catkin specific configuration
+# Declare catkin specific configuration to be passed to dependent projects
 ################################################################################
 catkin_package(
   INCLUDE_DIRS include

--- a/open_manipulator_dynamixel_ctrl/package.xml
+++ b/open_manipulator_dynamixel_ctrl/package.xml
@@ -1,16 +1,17 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>open_manipulator_dynamixel_ctrl</name>
-  <version>0.1.1</version>
+  <version>1.0.0</version>
   <description>
     The Dynamixel controller package based on Dynamixel-Workbench for OpenManipulator.
   </description>
   <license>Apache 2.0</license>
   <author email="thlim@robotis.com">Darby Lim</author>
   <maintainer email="pyo@robotis.com">Pyo</maintainer>
-  <url type="bugtracker">https://github.com/ROBOTIS-GIT/open_manipulator/issues</url>
+  <url type="website">http://wiki.ros.org/open_manipulator_dynamixel_ctrl</url>
+  <url type="emanual">http://emanual.robotis.com/docs/en/platform/openmanipulator</url>
   <url type="repository">https://github.com/ROBOTIS-GIT/open_manipulator</url>
-  <url type="website">http://emanual.robotis.com/docs/en/platform/openmanipulator</url>
+  <url type="bugtracker">https://github.com/ROBOTIS-GIT/open_manipulator/issues</url>
   <buildtool_depend>catkin</buildtool_depend>
   <depend>roscpp</depend>
   <depend>std_msgs</depend>

--- a/open_manipulator_moveit/CHANGELOG.rst
+++ b/open_manipulator_moveit/CHANGELOG.rst
@@ -1,0 +1,26 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package open_manipulator_moveit
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1.0.0 (2018-06-01)
+------------------
+* package reconfiguration for OpenManipulator
+* added position only IK
+* added compability with book
+* deleted unused variables, 'chain' word
+* merged pull request `#34 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/34>`_ `#33 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/33>`_ `#32 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/32>`_ `#31 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/31>`_ `#27 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/27>`_ `#26 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/26>`_ `#25 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/25>`_
+* Contributors: Darby Lim, Pyo
+
+0.1.1 (2018-03-15)
+------------------
+* none
+
+0.1.0 (2018-03-14)
+------------------
+* modified moveit set and gripper control
+* modified gazebo and moveit setting
+* modified gazebo sim
+* modified description
+* modified cmake, packages files for release
+* refactoring for release
+* Contributors: Darby Lim, Pyo

--- a/open_manipulator_moveit/CMakeLists.txt
+++ b/open_manipulator_moveit/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# CMake
+# Set minimum required version of cmake, project name and compile options
 ################################################################################
 cmake_minimum_required(VERSION 2.8.3)
 project(open_manipulator_moveit)
@@ -7,7 +7,7 @@ project(open_manipulator_moveit)
 add_compile_options(-std=c++11)
 
 ################################################################################
-# Packages
+# Find catkin packages and libraries for catkin and system dependencies
 ################################################################################
 find_package(catkin REQUIRED COMPONENTS
   moveit_ros_move_group
@@ -21,6 +21,10 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 ################################################################################
+# Setup for python modules and scripts
+################################################################################
+
+################################################################################
 # Declare ROS messages, services and actions
 ################################################################################
 
@@ -29,7 +33,7 @@ find_package(catkin REQUIRED COMPONENTS
 ################################################################################
 
 ################################################################################
-# Catkin specific configuration
+# Declare catkin specific configuration to be passed to dependent projects
 ################################################################################
 catkin_package(
   INCLUDE_DIRS include

--- a/open_manipulator_moveit/package.xml
+++ b/open_manipulator_moveit/package.xml
@@ -1,16 +1,17 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>open_manipulator_moveit</name>
-  <version>0.1.1</version>
+  <version>1.0.0</version>
   <description>
      An automatically generated packages including all the configurations and launch files for OpenManipulator by using MoveIt! Motion Planning Framework.
   </description>
   <license>Apache 2.0</license>
   <author email="thlim@robotis.com">Darby Lim</author>
   <maintainer email="pyo@robotis.com">Pyo</maintainer>
-  <url type="bugtracker">https://github.com/ROBOTIS-GIT/open_manipulator/issues</url>
+  <url type="website">http://wiki.ros.org/open_manipulator_moveit</url>
+  <url type="emanual">http://emanual.robotis.com/docs/en/platform/openmanipulator</url>
   <url type="repository">https://github.com/ROBOTIS-GIT/open_manipulator</url>
-  <url type="website">http://emanual.robotis.com/docs/en/platform/openmanipulator</url>
+  <url type="bugtracker">https://github.com/ROBOTIS-GIT/open_manipulator/issues</url>
   <buildtool_depend>catkin</buildtool_depend>
   <depend>moveit_ros_move_group</depend>
   <depend>moveit_kinematics</depend>

--- a/open_manipulator_position_ctrl/CHANGELOG.rst
+++ b/open_manipulator_position_ctrl/CHANGELOG.rst
@@ -2,6 +2,18 @@
 Changelog for package open_manipulator_position_ctrl
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+1.0.0 (2018-06-01)
+------------------
+* package reconfiguration for OpenManipulator
+* added pick and place controller
+* added private node handler, init_position arg, state machine, task, joint limit param
+* added scaling factor for moving time and block making another path when robot moving
+* modified publisher, velocity scaling factor
+* modified serive to get pose data
+* deleted boost lib, unused variables
+* merged pull request `#34 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/34>`_ `#33 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/33>`_ `#31 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/31>`_ `#27 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/27>`_ `#26 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/26>`_ `#25 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/25>`_
+* Contributors: Darby Lim, Pyo
+
 0.1.1 (2018-03-15)
 ------------------
 * modified build setting for using yaml-cpp

--- a/open_manipulator_position_ctrl/CMakeLists.txt
+++ b/open_manipulator_position_ctrl/CMakeLists.txt
@@ -1,13 +1,14 @@
 ################################################################################
-# CMake
+# Set minimum required version of cmake, project name and compile options
 ################################################################################
 cmake_minimum_required(VERSION 2.8.3)
 project(open_manipulator_position_ctrl)
 
-set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+## Compile as C++11, supported in ROS Kinetic and newer
+add_compile_options(-std=c++11)
 
 ################################################################################
-# Packages
+# Find catkin packages and libraries for catkin and system dependencies
 ################################################################################
 find_package(catkin REQUIRED COMPONENTS
   roscpp
@@ -24,6 +25,10 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(Eigen3 REQUIRED)
 
 ################################################################################
+# Setup for python modules and scripts
+################################################################################
+
+################################################################################
 # Declare ROS messages, services and actions
 ################################################################################
 
@@ -32,7 +37,7 @@ find_package(Eigen3 REQUIRED)
 ################################################################################
 
 ################################################################################
-# Catkin specific configuration
+# Declare catkin specific configuration to be passed to dependent projects
 ################################################################################
 catkin_package(
   INCLUDE_DIRS include

--- a/open_manipulator_position_ctrl/package.xml
+++ b/open_manipulator_position_ctrl/package.xml
@@ -1,16 +1,17 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>open_manipulator_position_ctrl</name>
-  <version>0.1.1</version>
+  <version>1.0.0</version>
   <description>
     This packages based on MoveIt! framework to manipulate OpenManipulator
   </description>
   <license>Apache 2.0</license>
   <author email="thlim@robotis.com">Darby Lim</author>
   <maintainer email="pyo@robotis.com">Pyo</maintainer>
-  <url type="bugtracker">https://github.com/ROBOTIS-GIT/open_manipulator/issues</url>
+  <url type="website">http://wiki.ros.org/open_manipulator_position_ctrl</url>
+  <url type="emanual">http://emanual.robotis.com/docs/en/platform/openmanipulator</url>
   <url type="repository">https://github.com/ROBOTIS-GIT/open_manipulator</url>
-  <url type="website">http://emanual.robotis.com/docs/en/platform/openmanipulator</url>
+  <url type="bugtracker">https://github.com/ROBOTIS-GIT/open_manipulator/issues</url>
   <buildtool_depend>catkin</buildtool_depend>
   <depend>roscpp</depend>
   <depend>std_msgs</depend>


### PR DESCRIPTION
1.0.0 (2018-06-01)
------------------
* package reconfiguration for OpenManipulator
* added new stl files
* added urdf, rviz param, gazebo params, group
* added function to support protocol 1.0
* modified color, xacro server, mu1, mu2, collision range, joint limit
* modified joint_state_publisher, joint_states_publisher
* modified params of inertial, xacro, gazebo, collision, friction 
* modified urdf file names and collision geometry
* modified motor id, msg names
* modified description and package tree
* deleted unnecessary packages
* merged pull request `#34 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/34>`_ `#33 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/33>`_ `#32 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/32>`_ `#31 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/31>`_ `#27 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/27>`_ `#26 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/26>`_ `#25 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/25>`_
* Contributors: Darby Lim, Pyo