### PR TITLE
Fix urdf limits

### DIFF
--- a/open_manipulator_description/urdf/open_manipulator.urdf.xacro
+++ b/open_manipulator_description/urdf/open_manipulator.urdf.xacro
@@ -113,7 +113,7 @@
     <child link="link3"/>
     <origin xyz="0.0 0.0 0.058" rpy="0 0 0"/>
     <axis xyz="0 1 0"/>
-    <limit velocity="6.5" effort="1000" lower="${-pi*0.5}" upper="${pi*0.5}" />
+    <limit velocity="6.5" effort="1000" lower="${-pi*0.58}" upper="${pi*0.5}" />
   </joint>
 
   <!-- Transmission 2 -->
@@ -223,7 +223,7 @@
     <child link="link5"/>
     <origin xyz="0.124 0.0 0.0" rpy="0 0 0"/>
     <axis xyz="0 1 0"/>
-    <limit velocity="6.5" effort="1000" lower="${-pi*0.4}" upper="${pi*0.5}" />
+    <limit velocity="6.5" effort="1000" lower="${-pi*0.57}" upper="${pi*0.65}" />
   </joint>
 
   <!-- Transmission 4 -->

--- a/open_manipulator_position_ctrl/src/gripper_controller.cpp
+++ b/open_manipulator_position_ctrl/src/gripper_controller.cpp
@@ -154,8 +154,8 @@ void GripperController::gripperOnOffMsgCallback(const std_msgs::String::ConstPtr
 {
   open_manipulator_msgs::JointPosition joint_msg;
 
-  joint_msg.max_velocity_scaling_factor = 5.0;
-  joint_msg.max_accelerations_scaling_factor = 2.0;
+  joint_msg.max_velocity_scaling_factor = 1.0;
+  joint_msg.max_accelerations_scaling_factor = 1.0;
 
   if (msg->data == "grip_on")
   {


### PR DESCRIPTION
- Enlarging the urdf limits of `joint2` and `joint4` to fit better the hardware constraints.

As the code is right now, when trying to boot from positions like the ones below, moveit  fails with the following message:

```
[ WARN] [1541040645.964017736]: RRTConnect: Skipping invalid start state (invalid bounds)
[ERROR] [1541040645.964091193]: RRTConnect: Motion planning start tree could not be initialized!
```

![img_20181113_131420](https://user-images.githubusercontent.com/20625381/48392947-de6ebf80-e750-11e8-9cff-282e8480bb5d.jpg)
![img_20181113_131349](https://user-images.githubusercontent.com/20625381/48392953-e169b000-e750-11e8-9df6-ee7b90eca0b5.jpg)

- Fixing invalid velocity and acceleration factors  on `gripper_controller.cpp`, according to the following warning:

```
rostopic pub /open_manipulator/gripper std_msgs/String "data: 'grip_on'" 
---
[ WARN] [1541059721.500827051]: Invalid max_velocity_scaling_factor 5.000000 specified, defaulting to 1.000000 instead.
[ WARN] [1541059721.500873588]: Invalid max_acceleration_scaling_factor 2.000000 specified, defaulting to 1.000000 instead.
```

Open to discussions about more appropriate limits or factors.
