### PR TITLE
Support building with 'catkin build'

### DIFF
--- a/open_manipulator_controller/CMakeLists.txt
+++ b/open_manipulator_controller/CMakeLists.txt
@@ -37,6 +37,7 @@ find_package(Boost REQUIRED)
 ################################################################################
 catkin_package(
   INCLUDE_DIRS include
+  CATKIN_DEPENDS robotis_manipulator open_manipulator_libs
   DEPENDS Boost
 )
 
@@ -53,7 +54,7 @@ include_directories(
 
 add_executable(open_manipulator_controller src/open_manipulator_controller.cpp)
 add_dependencies(open_manipulator_controller ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-target_link_libraries(open_manipulator_controller ${catkin_LIBRARIES} ${Boost_LIBRARIES} robotis_manipulator open_manipulator_libs)
+target_link_libraries(open_manipulator_controller ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 
 

--- a/open_manipulator_libs/CMakeLists.txt
+++ b/open_manipulator_libs/CMakeLists.txt
@@ -34,6 +34,7 @@ find_package(Eigen3 REQUIRED)
 ################################################################################
 catkin_package(
   INCLUDE_DIRS include
+  LIBRARIES open_manipulator_libs
   CATKIN_DEPENDS dynamixel_workbench_toolbox
   DEPENDS EIGEN3
 )


### PR DESCRIPTION
Support building with `catkin build` as well. Of course `catkin_make` still runs normally.

Please note that this requires https://github.com/ROBOTIS-GIT/robotis_manipulator/pull/1

Error message when running `catkin build` in current state:
```
/usr/bin/ld: cannot find -lrobotis_manipulator
/usr/bin/ld: cannot find -lopen_manipulator_libs
```