### PR TITLE
Shutdown control_gui on keyboard interrupt

### DIFF
--- a/open_manipulator_control_gui/include/open_manipulator_control_gui/qnode.hpp
+++ b/open_manipulator_control_gui/include/open_manipulator_control_gui/qnode.hpp
@@ -75,6 +75,9 @@ public:
   bool setTaskSpacePath(std::vector<double> kinematics_pose, double path_time);
   bool setToolControl(std::vector<double> joint_angle);
 
+Q_SIGNALS:
+  void rosShutdown();
+
 private:
 	int init_argc;
 	char** init_argv;

--- a/open_manipulator_control_gui/src/main_window.cpp
+++ b/open_manipulator_control_gui/src/main_window.cpp
@@ -33,6 +33,7 @@ MainWindow::MainWindow(int argc, char** argv, QWidget *parent)
   ui.setupUi(this); // Calling this incidentally connects all ui's triggers to on_...() callbacks in this class.
   QObject::connect(ui.actionAbout_Qt, SIGNAL(triggered(bool)), qApp, SLOT(aboutQt())); // qApp is a global variable for the application
   connect(ui.tabWidget, SIGNAL(currentChanged(int)), this, SLOT(tabSelected()));
+  QObject::connect(&qnode, SIGNAL(rosShutdown()), this, SLOT(close()));
 
   qnode.init();
 

--- a/open_manipulator_control_gui/src/qnode.cpp
+++ b/open_manipulator_control_gui/src/qnode.cpp
@@ -69,6 +69,7 @@ void QNode::run() {
 		++count;
 	}
 	std::cout << "Ros shutdown, proceeding to close the gui." << std::endl;
+	Q_EMIT rosShutdown();
 }
 
 


### PR DESCRIPTION
Close gui window when pressing Ctrl-C on the terminal (currently stops after the message `Ros shutdown, proceeding to close the gui.`).