### PR TITLE
Share robot_name between nodes

### DIFF
--- a/open_manipulator_control_gui/src/qnode.cpp
+++ b/open_manipulator_control_gui/src/qnode.cpp
@@ -60,18 +60,20 @@ bool QNode::init() {
 	ros::start(); // explicitly needed since our nodehandle is going out of scope.
 	ros::NodeHandle n;
 
+  std::string robot_name = n.param<std::string>("robot_name", "open_manipulator");
+
   // msg publisher
-  open_manipulator_option_pub_ = n.advertise<std_msgs::String>("open_manipulator/option", 10);
+  open_manipulator_option_pub_ = n.advertise<std_msgs::String>(robot_name + "/option", 10);
   // msg subscriber
-  open_manipulator_states_sub_       = n.subscribe("open_manipulator/states", 10, &QNode::statesCallback, this);
-  open_manipulator_joint_states_sub_ = n.subscribe("open_manipulator/joint_states", 10, &QNode::jointStatesCallback, this);
-  open_manipulator_kinematics_pose_sub_ = n.subscribe("open_manipulator/kinematics_pose", 10, &QNode::kinematicsPoseCallback, this);
+  open_manipulator_states_sub_       = n.subscribe(robot_name + "/states", 10, &QNode::statesCallback, this);
+  open_manipulator_joint_states_sub_ = n.subscribe(robot_name + "/joint_states", 10, &QNode::jointStatesCallback, this);
+  open_manipulator_kinematics_pose_sub_ = n.subscribe(robot_name + "/kinematics_pose", 10, &QNode::kinematicsPoseCallback, this);
   // service client
-  goal_joint_space_path_client_ = n.serviceClient<open_manipulator_msgs::SetJointPosition>("open_manipulator/goal_joint_space_path");
-  goal_task_space_path_client_ = n.serviceClient<open_manipulator_msgs::SetKinematicsPose>("open_manipulator/goal_task_space_path");
-  goal_tool_control_client_ = n.serviceClient<open_manipulator_msgs::SetJointPosition>("open_manipulator/goal_tool_control");
-  set_actuator_state_client_ = n.serviceClient<open_manipulator_msgs::SetActuatorState>("open_manipulator/set_actuator_state");
-  goal_drawing_trajectory_client_ = n.serviceClient<open_manipulator_msgs::SetDrawingTrajectory>("open_manipulator/goal_drawing_trajectory");
+  goal_joint_space_path_client_ = n.serviceClient<open_manipulator_msgs::SetJointPosition>(robot_name + "/goal_joint_space_path");
+  goal_task_space_path_client_ = n.serviceClient<open_manipulator_msgs::SetKinematicsPose>(robot_name + "/goal_task_space_path");
+  goal_tool_control_client_ = n.serviceClient<open_manipulator_msgs::SetJointPosition>(robot_name + "/goal_tool_control");
+  set_actuator_state_client_ = n.serviceClient<open_manipulator_msgs::SetActuatorState>(robot_name + "/set_actuator_state");
+  goal_drawing_trajectory_client_ = n.serviceClient<open_manipulator_msgs::SetDrawingTrajectory>(robot_name + "/goal_drawing_trajectory");
 
   start();
 	return true;

--- a/open_manipulator_controller/launch/open_manipulator_controller.launch
+++ b/open_manipulator_controller/launch/open_manipulator_controller.launch
@@ -2,11 +2,11 @@
   <arg name="use_robot_name"         default="open_manipulator"/>
   <arg name="dynamixel_usb_port"     default="/dev/ttyUSB0"/>
   <arg name="dynamixel_baud_rate"    default="1000000"/>
-
   <arg name="use_platform"           default="true"/>
 
+  <param name="robot_name"           value="$(arg use_robot_name)"/>
+
   <node pkg="open_manipulator_controller" type="open_manipulator_controller" name="open_manipulator_controller" output="screen">
-      <param name="robot_name"           value="$(arg use_robot_name)"/>
       <param name="usb_port"             value="$(arg dynamixel_usb_port)"/>
       <param name="baud_rate"            value="$(arg dynamixel_baud_rate)"/>
       <param name="using_platform"       value="$(arg use_platform)"/>

--- a/open_manipulator_controller/src/open_manipulator_controller.cpp
+++ b/open_manipulator_controller/src/open_manipulator_controller.cpp
@@ -28,7 +28,7 @@ OM_CONTROLLER::OM_CONTROLLER()
      using_platform_(false),
      tool_position_(0.0)
 {
-  robot_name_             = priv_node_handle_.param<std::string>("robot_name", "open_manipulator");
+  robot_name_             = node_handle_.param<std::string>("robot_name", "open_manipulator");
   std::string usb_port    = priv_node_handle_.param<std::string>("usb_port", "/dev/ttyUSB0");
   std::string baud_rate   = priv_node_handle_.param<std::string>("baud_rate", "1000000");
 
@@ -137,7 +137,7 @@ void OM_CONTROLLER::initPublisher()
 void OM_CONTROLLER::initSubscriber()
 {
   // msg subscriber
-  open_manipulator_option_client_ = node_handle_.subscribe("open_manipulator/option", 10, &OM_CONTROLLER::printManipulatorSettingCallback, this);
+  open_manipulator_option_client_ = node_handle_.subscribe(robot_name_ + "/option", 10, &OM_CONTROLLER::printManipulatorSettingCallback, this);
   // service server
   goal_joint_space_path_server_ = node_handle_.advertiseService(robot_name_ + "/goal_joint_space_path", &OM_CONTROLLER::goalJointSpacePathCallback, this);
   goal_task_space_path_server_ =  node_handle_.advertiseService(robot_name_ + "/goal_task_space_path", &OM_CONTROLLER::goalTaskSpacePathCallback, this);

--- a/open_manipulator_teleop/src/open_manipulator_teleop_joystick.cpp
+++ b/open_manipulator_teleop/src/open_manipulator_teleop_joystick.cpp
@@ -24,7 +24,7 @@ OM_TELEOP::OM_TELEOP()
     :node_handle_(""),
      priv_node_handle_("~")
 {
-  robot_name_     = priv_node_handle_.param<std::string>("robot_name", "open_manipulator");
+  robot_name_     = node_handle_.param<std::string>("robot_name", "open_manipulator");
   present_joint_angle.resize(NUM_OF_JOINT);
   present_kinematic_position.resize(3);
 

--- a/open_manipulator_teleop/src/open_manipulator_teleop_keyboard.cpp
+++ b/open_manipulator_teleop/src/open_manipulator_teleop_keyboard.cpp
@@ -24,7 +24,7 @@ OM_TELEOP::OM_TELEOP()
     :node_handle_(""),
      priv_node_handle_("~")
 {
-  robot_name_     = priv_node_handle_.param<std::string>("robot_name", "open_manipulator");
+  robot_name_     = node_handle_.param<std::string>("robot_name", "open_manipulator");
   present_joint_angle.resize(NUM_OF_JOINT);
   present_kinematic_position.resize(3);
 


### PR DESCRIPTION
Setting the `robot_name` parameter to global and sharing it between nodes (`controller`, `teleop`, `control_gui`).

In the future would be nice to have a way to use this parameter on joint_state_publisher's too, for `description` and `moveit_controller` (maybe environment variable, like the turtlebot_model?) .
```
 <rosparam param="source_list">["open_manipulator/joint_states"]</rosparam>
```

With this control_gui and teleop nodes run normally when setting `robot_name` to values other than `open_manipulator`.