### PR TITLE
Update start_state after execution on Moveit

### DIFF
--- a/open_manipulator_controller/include/open_manipulator_controller/open_manipulator_controller.h
+++ b/open_manipulator_controller/include/open_manipulator_controller/open_manipulator_controller.h
@@ -24,6 +24,7 @@
 #include <geometry_msgs/PoseStamped.h>
 #include <std_msgs/Float64.h>
 #include <std_msgs/String.h>
+#include <std_msgs/Empty.h>
 #include <boost/thread.hpp>
 #include <unistd.h>
 
@@ -71,6 +72,7 @@ class OpenManipulatorController
   std::vector<ros::Publisher> open_manipulator_kinematics_pose_pub_;
   ros::Publisher open_manipulator_joint_states_pub_;
   std::vector<ros::Publisher> gazebo_goal_joint_position_pub_;
+  ros::Publisher moveit_update_start_state_;
 
   // ROS Subscribers
   ros::Subscriber open_manipulator_option_sub_;

--- a/open_manipulator_controller/src/open_manipulator_controller.cpp
+++ b/open_manipulator_controller/src/open_manipulator_controller.cpp
@@ -157,6 +157,10 @@ void OpenManipulatorController::initPublisher()
       gazebo_goal_joint_position_pub_.push_back(pb);
     }
   }
+  if (using_moveit_ == true)
+  {
+    moveit_update_start_state_ = node_handle_.advertise<std_msgs::Empty>("rviz/moveit/update_start_state", 10);
+  }
 }
 void OpenManipulatorController::initSubscriber()
 {
@@ -746,6 +750,12 @@ void OpenManipulatorController::moveitTimer(double present_time)
       {
         step_cnt = 0;
         moveit_plan_flag_ = false;
+        if (moveit_update_start_state_.getNumSubscribers() == 0)
+        {
+          robotis_manipulator_log::warn("Could not update the start state! Enable External Communications at the Moveit Plugin");
+        }
+        std_msgs::Empty msg;
+        moveit_update_start_state_.publish(msg);
       }
     }
   }

--- a/open_manipulator_moveit/launch/moveit.rviz
+++ b/open_manipulator_moveit/launch/moveit.rviz
@@ -40,7 +40,7 @@ Visualization Manager:
       Enabled: true
       Move Group Namespace: ""
       MoveIt_Allow_Approximate_IK: false
-      MoveIt_Allow_External_Program: false
+      MoveIt_Allow_External_Program: true
       MoveIt_Allow_Replanning: false
       MoveIt_Allow_Sensor_Positioning: false
       MoveIt_Goal_Tolerance: 0


### PR DESCRIPTION
Hello all,

Great to see that the Moveit Plan/Execution bug is fixed.

Adding some code to update the start state automatically after executing trajectories on Moveit (which is the default for standard controllers).

It works by sending an request to `/rviz/moveit/update_start_state` (which requires the `Allow External Connections` flag to be enabled).