### PR TITLE
Use NUM_OF_JOINT on open_manipulator_teleop

### DIFF
--- a/open_manipulator_teleop/src/open_manipulator_teleop_joystick.cpp
+++ b/open_manipulator_teleop/src/open_manipulator_teleop_joystick.cpp
@@ -146,7 +146,7 @@ bool OpenManipulatorTeleop::setTaskSpacePathFromPresentPositionOnly(std::vector<
 void OpenManipulatorTeleop::setGoal(const char* str)
 {
   std::vector<double> goalPose;  goalPose.resize(3, 0.0);
-  std::vector<double> goalJoint; goalJoint.resize(4, 0.0);
+  std::vector<double> goalJoint; goalJoint.resize(NUM_OF_JOINT, 0.0);
 
   if(str == "x+")
   {

--- a/open_manipulator_teleop/src/open_manipulator_teleop_keyboard.cpp
+++ b/open_manipulator_teleop/src/open_manipulator_teleop_keyboard.cpp
@@ -190,7 +190,7 @@ void OpenManipulatorTeleop::printText()
 void OpenManipulatorTeleop::setGoal(char ch)
 {
   std::vector<double> goalPose;  goalPose.resize(3, 0.0);
-  std::vector<double> goalJoint; goalJoint.resize(4, 0.0);
+  std::vector<double> goalJoint; goalJoint.resize(NUM_OF_JOINT, 0.0);
 
   if(ch == 'w' || ch == 'W')
   {


### PR DESCRIPTION
Similar situation in `control_gui` (below), but in that case we have no access to the variable defined in `qnode.hpp`, so leaving it as it is.
https://github.com/ROBOTIS-GIT/open_manipulator/blob/9b1e4b472d0093bff2d658a10af1ffdf31270592/open_manipulator_control_gui/src/main_window.cpp#L58