### PR TITLE
revise the U2D2 setup script

### DIFF
--- a/open_manipulator_x_controller/scripts/create_udev_rules
+++ b/open_manipulator_x_controller/scripts/create_udev_rules
@@ -1,12 +1,11 @@
 #!/bin/bash
 
 echo ""
-echo "This script copies a udev rule to /etc to facilitate bringing"
-echo "up the OpenManipulator usb connection."
+echo "This script copies the udev rule to /etc/udev/rules.d/"
+echo "to configure the U2D2 device for the OpenMANIPULATOR."
 echo ""
 
-# sudo cp `rospack find open_manipulator_controller`/99-open-manipulator-cdc.rules /etc/udev/rules.d/
-sudo cp /home/robotis/robotis_ws/src/open_manipulator/open_manipulator_x_controller/99-open-manipulator-cdc.rules /etc/udev/rules.d/
+sudo cp `ros2 pkg prefix open_manipulator_x_controller`/share/open_manipulator_x_controller/99-open-manipulator-cdc.rules /etc/udev/rules.d/
 
 echo ""
 echo "Reload rules"


### PR DESCRIPTION
Incorrect script location fails setting the U2D2 FTDI driver.
This resolves communication issues between OpenMANIPULATOR and Remote PC