### PR TITLE
Added hasPID parameter to the mimic joint

### DIFF
--- a/open_manipulator_description/urdf/open_manipulator.gazebo.xacro
+++ b/open_manipulator_description/urdf/open_manipulator.gazebo.xacro
@@ -59,6 +59,7 @@
       <mimicJoint>gripper_sub</mimicJoint>
       <multiplier>1.0</multiplier>
       <offset>0.0</offset>
+      <hasPID>/gazebo_ros_control/pid_gains/gripper_sub</hasPID>
     </plugin>
   </gazebo>
 


### PR DESCRIPTION
Without the hasPID parameter and the gazebo controller submitted in PR for the simulation package, the gripper is unable to pick up objects. This and https://github.com/ROBOTIS-GIT/open_manipulator_simulations/pull/18 will fix this.