### PR TITLE
repair RefLink xacro macro implementation

### DIFF
--- a/open_manipulator_description/launch/open_manipulator_upload.launch
+++ b/open_manipulator_description/launch/open_manipulator_upload.launch
@@ -1,4 +1,6 @@
 <launch>
+  <arg name="interface_type" default="position"/>
+
   <param name="robot_description"
-         command="$(find xacro)/xacro --inorder '$(find open_manipulator_description)/urdf/open_manipulator_robot.urdf.xacro'"/>
+         command="$(find xacro)/xacro --inorder '$(find open_manipulator_description)/urdf/open_manipulator_robot.urdf.xacro' interface_type:=$(arg interface_type)"/>
 </launch>

--- a/open_manipulator_description/urdf/open_manipulator.gazebo.xacro
+++ b/open_manipulator_description/urdf/open_manipulator.gazebo.xacro
@@ -18,25 +18,25 @@
   <gazebo reference="world"/>
 
   <!-- Link1 -->
-  <RefLink ref="link1"/>
+  <xacro:RefLink ref="link1"/>
 
   <!-- Link2 -->
-  <RefLink ref="link2"/>
+  <xacro:RefLink ref="link2"/>
 
   <!-- Link3 -->
-  <RefLink ref="link3"/>
+  <xacro:RefLink ref="link3"/>
 
   <!-- Link4 -->
-  <RefLink ref="link4"/>
+  <xacro:RefLink ref="link4"/>
 
   <!-- Link5 -->
-  <RefLink ref="link5"/>
+  <xacro:RefLink ref="link5"/>
 
   <!-- gripper_link -->
-  <RefLink ref="gripper_link"/>
+  <xacro:RefLink ref="gripper_link"/>
 
   <!-- gripper_link_sub -->
-  <RefLink ref="gripper_link_sub"/>
+  <xacro:RefLink ref="gripper_link_sub"/>
 
   <!-- end effector link -->
   <gazebo reference="end_effector_link">

--- a/open_manipulator_description/urdf/open_manipulator.transmission.xacro
+++ b/open_manipulator_description/urdf/open_manipulator.transmission.xacro
@@ -1,6 +1,10 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
+  <!-- Arg to alternate between effort/position interface -->
+  <xacro:arg name="interface_type" default="position"/>
+  <xacro:property name="interface_type" value="$(arg interface_type)"/>
+
   <!-- Transmission macro -->
   <xacro:macro name="SimpleTransmissionPosition" params="joint n">
     <transmission name="tran${n}">
@@ -27,17 +31,35 @@
     </transmission>
   </xacro:macro>
 
-  <!-- Transmission 1 -->
-  <xacro:SimpleTransmissionPosition n="1" joint="joint1" />
+  <!-- Transmissions for Effort Interface -->
+  <xacro:if value="${interface_type == 'effort'}">
+    <!-- Transmission 1 -->
+    <xacro:SimpleTransmissionEffort n="1" joint="joint1" />
 
-  <!-- Transmission 2 -->
-  <xacro:SimpleTransmissionPosition n="2" joint="joint2" />
+    <!-- Transmission 2 -->
+    <xacro:SimpleTransmissionEffort n="2" joint="joint2" />
+  
+    <!-- Transmission 3 -->
+    <xacro:SimpleTransmissionEffort n="3" joint="joint3" />
+  
+    <!-- Transmission 4 -->
+    <xacro:SimpleTransmissionEffort n="4" joint="joint4" />
+  </xacro:if>
 
-  <!-- Transmission 3 -->
-  <xacro:SimpleTransmissionPosition n="3" joint="joint3" />
+  <!-- Transmissions for Position Interface -->
+  <xacro:if value="${interface_type == 'position'}">
+    <!-- Transmission 1 -->
+    <xacro:SimpleTransmissionPosition n="1" joint="joint1" />
 
-  <!-- Transmission 4 -->
-  <xacro:SimpleTransmissionPosition n="4" joint="joint4" />
+    <!-- Transmission 2 -->
+    <xacro:SimpleTransmissionPosition n="2" joint="joint2" />
+  
+    <!-- Transmission 3 -->
+    <xacro:SimpleTransmissionPosition n="3" joint="joint3" />
+  
+    <!-- Transmission 4 -->
+    <xacro:SimpleTransmissionPosition n="4" joint="joint4" />
+  </xacro:if>
 
   <!-- Transmission 5 -->
   <xacro:SimpleTransmissionEffort n="5" joint="gripper" />


### PR DESCRIPTION
Gazebo Material were not working because macro to setup reference to links was being called wrong, added xacro: to the calls in order to repair it