### PR TITLE
Update Dockerfile to use base ROS Humble image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the base ROS2 humble image
-FROM moveit/moveit2:humble-source
+FROM ros:humble
 
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
     libboost-all-dev \
     ros-${ROS_DISTRO}-controller-manager \
     ros-${ROS_DISTRO}-ros2-controllers \
+    ros-${ROS_DISTRO}-moveit \
     && rm -rf /var/lib/apt/lists/*
 
 ENV COLCON_WS=/root/colcon_ws
@@ -22,12 +23,10 @@ RUN mkdir -p ${COLCON_WS}/src && \
     git clone -b humble https://github.com/ROBOTIS-GIT/open_manipulator.git
 
 RUN bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash && \
-    source /root/ws_moveit/install/setup.bash && \
     cd ${COLCON_WS} && \
     colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release"
 
 RUN echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> ~/.bashrc
-RUN echo "source /root/ws_moveit/install/setup.bash" >> ~/.bashrc
 RUN echo "source ${COLCON_WS}/install/setup.bash" >> ~/.bashrc
 
 CMD ["bash"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: open_manipulator_x
     tty: true
     restart: always
     cap_add:


### PR DESCRIPTION
### Description  
This pull request updates the Dockerfile to use the base ROS Humble image and adds support for the ARM64 architecture. These changes improve compatibility across different hardware platforms and ensure a more maintainable development environment.

### Summary of Changes  
- **Dockerfile Update:**  
  - Changed the base image from `moveit/moveit2:humble-source` to `ros:humble`.  
  - Adjusted package installations to match dependencies required for ROS Humble.  
  - Added support for the ARM64 architecture, enabling the project to run on ARM-based systems.

### Motivation  
Expanding support to ARM64 architecture allows the project to run on a wider range of devices, including ARM-based development boards and embedded systems.

### Testing & Validation  
- **Local Testing:**  
  The updated Docker image was successfully built on both x86_64 and ARM64 architectures. All existing functionalities were verified to work correctly across different hardware platforms.

### Request for Review  
Please review the changes and provide any feedback or suggestions. Your input is valuable to ensure that this update integrates smoothly with the existing development workflow.
