### PR TITLE
Support Time-based Profile as Default Configuration for OMY

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -76,10 +76,11 @@ ENV PYTHONPATH=$PYTHONPATH:/usr/local/lib
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install realsense-viewer dependencies
+# Install realsense dependencies
 RUN apt-get update && apt-get install -y \
     libusb-1.0-0-dev \
     libglfw3-dev \
+    ros-${ROS_DISTRO}-image-transport-plugins \
     && rm -rf /var/lib/apt/lists/*
 
 ENV COLCON_WS=/root/ros2_ws

--- a/open_manipulator_bringup/launch/omx.launch.py
+++ b/open_manipulator_bringup/launch/omx.launch.py
@@ -66,6 +66,11 @@ def generate_launch_description():
             default_value='true',
             description='Whether to launch the init_position node',
         ),
+        DeclareLaunchArgument(
+            'ros2_control_type',
+            default_value='omx',
+            description='Type of ROS2 control',
+        ),
     ]
 
     # Launch configurations
@@ -76,6 +81,7 @@ def generate_launch_description():
     fake_sensor_commands = LaunchConfiguration('fake_sensor_commands')
     port_name = LaunchConfiguration('port_name')
     init_position = LaunchConfiguration('init_position')
+    ros2_control_type = LaunchConfiguration('ros2_control_type')
 
     # Generate URDF file using xacro
     urdf_file = Command([
@@ -102,6 +108,9 @@ def generate_launch_description():
         ' ',
         'port_name:=',
         port_name,
+        ' ',
+        'ros2_control_type:=',
+        ros2_control_type,
     ])
 
     # Paths for configuration files

--- a/open_manipulator_bringup/launch/omy_3m.launch.py
+++ b/open_manipulator_bringup/launch/omy_3m.launch.py
@@ -61,6 +61,11 @@ def generate_launch_description():
             default_value='false',
             description='Whether to launch the init_position node',
         ),
+        DeclareLaunchArgument(
+            'ros2_control_type',
+            default_value='omy_3m',
+            description='Type of ROS2 control',
+        ),
     ]
 
     # Launch configurations
@@ -70,6 +75,7 @@ def generate_launch_description():
     use_fake_hardware = LaunchConfiguration('use_fake_hardware')
     fake_sensor_commands = LaunchConfiguration('fake_sensor_commands')
     init_position = LaunchConfiguration('init_position')
+    ros2_control_type = LaunchConfiguration('ros2_control_type')
 
     # Generate URDF file using xacro
     urdf_file = Command([
@@ -93,6 +99,9 @@ def generate_launch_description():
         ' ',
         'fake_sensor_commands:=',
         fake_sensor_commands,
+        ' ',
+        'ros2_control_type:=',
+        ros2_control_type,
     ])
 
     # Paths for configuration files

--- a/open_manipulator_bringup/launch/omy_f3m.launch.py
+++ b/open_manipulator_bringup/launch/omy_f3m.launch.py
@@ -61,6 +61,11 @@ def generate_launch_description():
             default_value='false',
             description='Whether to launch the init_position node',
         ),
+        DeclareLaunchArgument(
+            'ros2_control_type',
+            default_value='omy_f3m',
+            description='Type of ROS2 control',
+        ),
     ]
 
     # Launch configurations
@@ -70,6 +75,7 @@ def generate_launch_description():
     use_fake_hardware = LaunchConfiguration('use_fake_hardware')
     fake_sensor_commands = LaunchConfiguration('fake_sensor_commands')
     init_position = LaunchConfiguration('init_position')
+    ros2_control_type = LaunchConfiguration('ros2_control_type')
 
     # Generate URDF file using xacro
     urdf_file = Command([
@@ -93,6 +99,9 @@ def generate_launch_description():
         ' ',
         'fake_sensor_commands:=',
         fake_sensor_commands,
+        ' ',
+        'ros2_control_type:=',
+        ros2_control_type,
     ])
 
     # Paths for configuration files

--- a/open_manipulator_bringup/launch/omy_f3m_follower_ai.launch.py
+++ b/open_manipulator_bringup/launch/omy_f3m_follower_ai.launch.py
@@ -61,6 +61,11 @@ def generate_launch_description():
             default_value='false',
             description='Whether to launch the init_position node',
         ),
+        DeclareLaunchArgument(
+            'ros2_control_type',
+            default_value='omy_f3m',
+            description='Type of ROS2 control',
+        ),
     ]
 
     # Launch configurations
@@ -70,6 +75,7 @@ def generate_launch_description():
     use_fake_hardware = LaunchConfiguration('use_fake_hardware')
     fake_sensor_commands = LaunchConfiguration('fake_sensor_commands')
     init_position = LaunchConfiguration('init_position')
+    ros2_control_type = LaunchConfiguration('ros2_control_type')
 
     # Generate URDF file using xacro
     urdf_file = Command([
@@ -93,6 +99,9 @@ def generate_launch_description():
         ' ',
         'fake_sensor_commands:=',
         fake_sensor_commands,
+        ' ',
+        'ros2_control_type:=',
+        ros2_control_type,
     ])
 
     # Paths for configuration files

--- a/open_manipulator_bringup/launch/omy_l100_leader_ai.launch.py
+++ b/open_manipulator_bringup/launch/omy_l100_leader_ai.launch.py
@@ -64,6 +64,11 @@ def generate_launch_description():
             default_value='false',
             description='Whether to launch the self-collision detection node',
         ),
+        DeclareLaunchArgument(
+            'ros2_control_type',
+            default_value='omy_l100',
+            description='Type of ROS2 control',
+        ),
     ]
 
     # Launch configurations
@@ -73,6 +78,7 @@ def generate_launch_description():
     use_fake_hardware = LaunchConfiguration('use_fake_hardware')
     fake_sensor_commands = LaunchConfiguration('fake_sensor_commands')
     port_name = LaunchConfiguration('port_name')
+    ros2_control_type = LaunchConfiguration('ros2_control_type')
 
     # Generate URDF file using xacro
     urdf_file = Command([
@@ -99,6 +105,9 @@ def generate_launch_description():
         ' ',
         'port_name:=',
         port_name,
+        ' ',
+        'ros2_control_type:=',
+        ros2_control_type,
     ])
 
     # Paths for configuration files

--- a/open_manipulator_description/ros2_control/omy_3m.ros2_control.xacro
+++ b/open_manipulator_description/ros2_control/omy_3m.ros2_control.xacro
@@ -92,9 +92,7 @@
         <state_interface name="Present Position"/>
         <state_interface name="Present Velocity"/>
         <state_interface name="Present Current"/>
-        <state_interface name="Torque Enable"/>
-        <state_interface name="Present Input Voltage"/>
-        <param name="Drive Mode">0</param>
+        <param name="Drive Mode">4</param>
         <param name="Velocity Limit">3591</param>
         <param name="Acceleration Limit">8050</param>
         <param name="Profile Velocity">3591</param>
@@ -105,6 +103,8 @@
         <param name="Velocity P Gain">41387</param>
         <param name="Velocity I Gain">1565630</param>
         <param name="Operating Mode">3</param>
+        <param name="Profile Acceleration Time">5</param>
+        <param name="Profile Time">15</param>
       </gpio>
       <gpio name="dxl2">
         <param name="type">dxl</param>
@@ -113,9 +113,7 @@
         <state_interface name="Present Position"/>
         <state_interface name="Present Velocity"/>
         <state_interface name="Present Current"/>
-        <state_interface name="Torque Enable"/>
-        <state_interface name="Present Input Voltage"/>
-        <param name="Drive Mode">1</param>
+        <param name="Drive Mode">5</param>
         <param name="Velocity Limit">3591</param>
         <param name="Acceleration Limit">8050</param>
         <param name="Profile Velocity">3591</param>
@@ -125,6 +123,8 @@
         <param name="Velocity P Gain">41387</param>
         <param name="Velocity I Gain">1565630</param>
         <param name="Operating Mode">3</param>
+        <param name="Profile Acceleration Time">5</param>
+        <param name="Profile Time">15</param>
       </gpio>
       <gpio name="dxl3">
         <param name="type">dxl</param>
@@ -133,9 +133,7 @@
         <state_interface name="Present Position"/>
         <state_interface name="Present Velocity"/>
         <state_interface name="Present Current"/>
-        <state_interface name="Torque Enable"/>
-        <state_interface name="Present Input Voltage"/>
-        <param name="Drive Mode">0</param>
+        <param name="Drive Mode">4</param>
         <param name="Velocity Limit">6486</param>
         <param name="Acceleration Limit">8050</param>
         <param name="Profile Velocity">6486</param>
@@ -145,6 +143,8 @@
         <param name="Velocity P Gain">18184</param>
         <param name="Velocity I Gain">1585331</param>
         <param name="Operating Mode">3</param>
+        <param name="Profile Acceleration Time">5</param>
+        <param name="Profile Time">15</param>
       </gpio>
       <gpio name="dxl4">
         <param name="type">dxl</param>
@@ -153,9 +153,7 @@
         <state_interface name="Present Position"/>
         <state_interface name="Present Velocity"/>
         <state_interface name="Present Current"/>
-        <state_interface name="Torque Enable"/>
-        <state_interface name="Present Input Voltage"/>
-        <param name="Drive Mode">1</param>
+        <param name="Drive Mode">5</param>
         <param name="Velocity Limit">6486</param>
         <param name="Acceleration Limit">8050</param>
         <param name="Profile Velocity">6486</param>
@@ -165,6 +163,8 @@
         <param name="Velocity P Gain">18184</param>
         <param name="Velocity I Gain">1585331</param>
         <param name="Operating Mode">3</param>
+        <param name="Profile Acceleration Time">5</param>
+        <param name="Profile Time">15</param>
       </gpio>
       <gpio name="dxl5">
         <param name="type">dxl</param>
@@ -173,9 +173,7 @@
         <state_interface name="Present Position"/>
         <state_interface name="Present Velocity"/>
         <state_interface name="Present Current"/>
-        <state_interface name="Torque Enable"/>
-        <state_interface name="Present Input Voltage"/>
-        <param name="Drive Mode">0</param>
+        <param name="Drive Mode">4</param>
         <param name="Velocity Limit">6486</param>
         <param name="Acceleration Limit">8050</param>
         <param name="Profile Velocity">6486</param>
@@ -185,6 +183,8 @@
         <param name="Velocity P Gain">18184</param>
         <param name="Velocity I Gain">1585331</param>
         <param name="Operating Mode">3</param>
+        <param name="Profile Acceleration Time">5</param>
+        <param name="Profile Time">15</param>
       </gpio>
       <gpio name="dxl6">
         <param name="type">dxl</param>
@@ -193,9 +193,7 @@
         <state_interface name="Present Position"/>
         <state_interface name="Present Velocity"/>
         <state_interface name="Present Current"/>
-        <state_interface name="Torque Enable"/>
-        <state_interface name="Present Input Voltage"/>
-        <param name="Drive Mode">1</param>
+        <param name="Drive Mode">5</param>
         <param name="Velocity Limit">6486</param>
         <param name="Acceleration Limit">8050</param>
         <param name="Profile Velocity">6486</param>
@@ -205,6 +203,8 @@
         <param name="Velocity P Gain">18184</param>
         <param name="Velocity I Gain">1585331</param>
         <param name="Operating Mode">3</param>
+        <param name="Profile Acceleration Time">5</param>
+        <param name="Profile Time">15</param>
       </gpio>
       <gpio name="omy_hat">
         <param name="type">controller</param>

--- a/open_manipulator_description/ros2_control/omy_f3m.ros2_control.xacro
+++ b/open_manipulator_description/ros2_control/omy_f3m.ros2_control.xacro
@@ -92,9 +92,7 @@
         <state_interface name="Present Position"/>
         <state_interface name="Present Velocity"/>
         <state_interface name="Present Current"/>
-        <state_interface name="Torque Enable"/>
-        <state_interface name="Present Input Voltage"/>
-        <param name="Drive Mode">0</param>
+        <param name="Drive Mode">4</param>
         <param name="Velocity Limit">3591</param>
         <param name="Acceleration Limit">8050</param>
         <param name="Profile Velocity">3591</param>
@@ -105,6 +103,8 @@
         <param name="Velocity P Gain">41387</param>
         <param name="Velocity I Gain">1565630</param>
         <param name="Operating Mode">3</param>
+        <param name="Profile Acceleration Time">5</param>
+        <param name="Profile Time">15</param>
       </gpio>
       <gpio name="dxl2">
         <param name="type">dxl</param>
@@ -113,9 +113,7 @@
         <state_interface name="Present Position"/>
         <state_interface name="Present Velocity"/>
         <state_interface name="Present Current"/>
-        <state_interface name="Torque Enable"/>
-        <state_interface name="Present Input Voltage"/>
-        <param name="Drive Mode">1</param>
+        <param name="Drive Mode">5</param>
         <param name="Velocity Limit">3591</param>
         <param name="Acceleration Limit">8050</param>
         <param name="Profile Velocity">3591</param>
@@ -125,6 +123,8 @@
         <param name="Velocity P Gain">41387</param>
         <param name="Velocity I Gain">1565630</param>
         <param name="Operating Mode">3</param>
+        <param name="Profile Acceleration Time">5</param>
+        <param name="Profile Time">15</param>
       </gpio>
       <gpio name="dxl3">
         <param name="type">dxl</param>
@@ -133,9 +133,7 @@
         <state_interface name="Present Position"/>
         <state_interface name="Present Velocity"/>
         <state_interface name="Present Current"/>
-        <state_interface name="Torque Enable"/>
-        <state_interface name="Present Input Voltage"/>
-        <param name="Drive Mode">0</param>
+        <param name="Drive Mode">4</param>
         <param name="Velocity Limit">6486</param>
         <param name="Acceleration Limit">8050</param>
         <param name="Profile Velocity">6486</param>
@@ -145,6 +143,8 @@
         <param name="Velocity P Gain">18184</param>
         <param name="Velocity I Gain">1585331</param>
         <param name="Operating Mode">3</param>
+        <param name="Profile Acceleration Time">5</param>
+        <param name="Profile Time">15</param>
       </gpio>
       <gpio name="dxl4">
         <param name="type">dxl</param>
@@ -153,9 +153,7 @@
         <state_interface name="Present Position"/>
         <state_interface name="Present Velocity"/>
         <state_interface name="Present Current"/>
-        <state_interface name="Torque Enable"/>
-        <state_interface name="Present Input Voltage"/>
-        <param name="Drive Mode">1</param>
+        <param name="Drive Mode">5</param>
         <param name="Velocity Limit">6486</param>
         <param name="Acceleration Limit">8050</param>
         <param name="Profile Velocity">6486</param>
@@ -165,6 +163,8 @@
         <param name="Velocity P Gain">18184</param>
         <param name="Velocity I Gain">1585331</param>
         <param name="Operating Mode">3</param>
+        <param name="Profile Acceleration Time">5</param>
+        <param name="Profile Time">15</param>
       </gpio>
       <gpio name="dxl5">
         <param name="type">dxl</param>
@@ -173,9 +173,7 @@
         <state_interface name="Present Position"/>
         <state_interface name="Present Velocity"/>
         <state_interface name="Present Current"/>
-        <state_interface name="Torque Enable"/>
-        <state_interface name="Present Input Voltage"/>
-        <param name="Drive Mode">0</param>
+        <param name="Drive Mode">4</param>
         <param name="Velocity Limit">6486</param>
         <param name="Acceleration Limit">8050</param>
         <param name="Profile Velocity">6486</param>
@@ -185,6 +183,8 @@
         <param name="Velocity P Gain">18184</param>
         <param name="Velocity I Gain">1585331</param>
         <param name="Operating Mode">3</param>
+        <param name="Profile Acceleration Time">5</param>
+        <param name="Profile Time">15</param>
       </gpio>
       <gpio name="dxl6">
         <param name="type">dxl</param>
@@ -193,9 +193,7 @@
         <state_interface name="Present Position"/>
         <state_interface name="Present Velocity"/>
         <state_interface name="Present Current"/>
-        <state_interface name="Torque Enable"/>
-        <state_interface name="Present Input Voltage"/>
-        <param name="Drive Mode">1</param>
+        <param name="Drive Mode">5</param>
         <param name="Velocity Limit">6486</param>
         <param name="Acceleration Limit">8050</param>
         <param name="Profile Velocity">6486</param>
@@ -205,6 +203,8 @@
         <param name="Velocity P Gain">18184</param>
         <param name="Velocity I Gain">1585331</param>
         <param name="Operating Mode">3</param>
+        <param name="Profile Acceleration Time">5</param>
+        <param name="Profile Time">15</param>
       </gpio>
       <gpio name="omy_hat">
         <param name="type">controller</param>

--- a/open_manipulator_description/ros2_control/omy_f3m_30hz.ros2_control.xacro
+++ b/open_manipulator_description/ros2_control/omy_f3m_30hz.ros2_control.xacro
@@ -1,0 +1,224 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:macro name="omy_f3m_system" params="name prefix port_name:=^|/dev/ttyAMA2 use_sim:=^|false use_fake_hardware:=^|false fake_sensor_commands:=^|false">
+    <ros2_control name="${name}" type="system" is_async="true">
+      <xacro:if value="$(arg use_sim)">
+        <hardware>
+          <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+        </hardware>
+      </xacro:if>
+      <xacro:unless value="$(arg use_sim)">
+        <hardware>
+          <xacro:if value="${use_fake_hardware}">
+            <plugin>fake_components/GenericSystem</plugin>
+            <param name="fake_sensor_commands">${fake_sensor_commands}</param>
+            <param name="state_following_offset">0.0</param>
+          </xacro:if>
+          <xacro:unless value="${use_fake_hardware}">
+            <plugin>dynamixel_hardware_interface/DynamixelHardware</plugin>
+            <param name="port_name">${port_name}</param>
+            <param name="baud_rate">6250000</param>
+            <param name="error_timeout_ms">500</param>
+            <param name="dynamixel_model_folder">/param/dxl_model</param>
+            <param name="number_of_joints">6</param>
+            <param name="number_of_transmissions">6</param>
+            <param name="disable_torque_at_init">true</param>
+            <param name="transmission_to_joint_matrix">
+              1, 0, 0, 0, 0, 0,
+              0, 1, 0, 0, 0, 0,
+              0, 0, 1, 0, 0, 0,
+              0, 0, 0, 1, 0, 0,
+              0, 0, 0, 0, 1, 0,
+              0, 0, 0, 0, 0, 1
+            </param>
+            <param name="joint_to_transmission_matrix">
+              1, 0, 0, 0, 0, 0,
+              0, 1, 0, 0, 0, 0,
+              0, 0, 1, 0, 0, 0,
+              0, 0, 0, 1, 0, 0,
+              0, 0, 0, 0, 1, 0,
+              0, 0, 0, 0, 0, 1
+            </param>
+            <param name="dynamixel_state_pub_msg_name">dynamixel_hardware_interface/dxl_state</param>
+            <param name="get_dynamixel_data_srv_name">dynamixel_hardware_interface/get_dxl_data</param>
+            <param name="set_dynamixel_data_srv_name">dynamixel_hardware_interface/set_dxl_data</param>
+            <param name="reboot_dxl_srv_name">dynamixel_hardware_interface/reboot_dxl</param>
+            <param name="set_dxl_torque_srv_name">dynamixel_hardware_interface/set_dxl_torque</param>
+          </xacro:unless>
+        </hardware>
+      </xacro:unless>
+
+      <joint name="${prefix}joint1">
+        <command_interface name="position"/>
+        <state_interface name="position"/>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </joint>
+      <joint name="${prefix}joint2">
+        <command_interface name="position"/>
+        <state_interface name="position"/>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </joint>
+      <joint name="${prefix}joint3">
+        <command_interface name="position"/>
+        <state_interface name="position"/>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </joint>
+      <joint name="${prefix}joint4">
+        <command_interface name="position"/>
+        <state_interface name="position"/>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </joint>
+      <joint name="${prefix}joint5">
+        <command_interface name="position"/>
+        <state_interface name="position"/>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </joint>
+      <joint name="${prefix}joint6">
+        <command_interface name="position"/>
+        <state_interface name="position"/>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </joint>
+
+      <gpio name="dxl1">
+        <param name="type">dxl</param>
+        <param name="ID">1</param>
+        <command_interface name="Goal Position"/>
+        <state_interface name="Present Position"/>
+        <state_interface name="Present Velocity"/>
+        <state_interface name="Present Current"/>
+        <param name="Drive Mode">4</param>
+        <param name="Velocity Limit">3591</param>
+        <param name="Acceleration Limit">8050</param>
+        <param name="Profile Velocity">3591</param>
+        <param name="Profile Acceleration">8050</param>
+        <param name="Homing Offset">0</param>
+        <param name="Return Delay Time">0</param>
+        <param name="Position P Gain">1583185</param>
+        <param name="Velocity P Gain">41387</param>
+        <param name="Velocity I Gain">1565630</param>
+        <param name="Operating Mode">3</param>
+        <param name="Profile Acceleration Time">20</param>
+        <param name="Profile Time">200</param>
+      </gpio>
+      <gpio name="dxl2">
+        <param name="type">dxl</param>
+        <param name="ID">2</param>
+        <command_interface name="Goal Position"/>
+        <state_interface name="Present Position"/>
+        <state_interface name="Present Velocity"/>
+        <state_interface name="Present Current"/>
+        <param name="Drive Mode">5</param>
+        <param name="Velocity Limit">3591</param>
+        <param name="Acceleration Limit">8050</param>
+        <param name="Profile Velocity">3591</param>
+        <param name="Profile Acceleration">8050</param>
+        <param name="Return Delay Time">0</param>
+        <param name="Position P Gain">1583185</param>
+        <param name="Velocity P Gain">41387</param>
+        <param name="Velocity I Gain">1565630</param>
+        <param name="Operating Mode">3</param>
+        <param name="Profile Acceleration Time">20</param>
+        <param name="Profile Time">200</param>
+      </gpio>
+      <gpio name="dxl3">
+        <param name="type">dxl</param>
+        <param name="ID">3</param>
+        <command_interface name="Goal Position"/>
+        <state_interface name="Present Position"/>
+        <state_interface name="Present Velocity"/>
+        <state_interface name="Present Current"/>
+        <param name="Drive Mode">4</param>
+        <param name="Velocity Limit">6486</param>
+        <param name="Acceleration Limit">8050</param>
+        <param name="Profile Velocity">6486</param>
+        <param name="Profile Acceleration">8050</param>
+        <param name="Return Delay Time">0</param>
+        <param name="Position P Gain">1583185</param>
+        <param name="Velocity P Gain">18184</param>
+        <param name="Velocity I Gain">1585331</param>
+        <param name="Operating Mode">3</param>
+        <param name="Profile Acceleration Time">20</param>
+        <param name="Profile Time">200</param>
+      </gpio>
+      <gpio name="dxl4">
+        <param name="type">dxl</param>
+        <param name="ID">4</param>
+        <command_interface name="Goal Position"/>
+        <state_interface name="Present Position"/>
+        <state_interface name="Present Velocity"/>
+        <state_interface name="Present Current"/>
+        <param name="Drive Mode">5</param>
+        <param name="Velocity Limit">6486</param>
+        <param name="Acceleration Limit">8050</param>
+        <param name="Profile Velocity">6486</param>
+        <param name="Profile Acceleration">8050</param>
+        <param name="Return Delay Time">0</param>
+        <param name="Position P Gain">1583185</param>
+        <param name="Velocity P Gain">18184</param>
+        <param name="Velocity I Gain">1585331</param>
+        <param name="Operating Mode">3</param>
+        <param name="Profile Acceleration Time">20</param>
+        <param name="Profile Time">200</param>
+      </gpio>
+      <gpio name="dxl5">
+        <param name="type">dxl</param>
+        <param name="ID">5</param>
+        <command_interface name="Goal Position"/>
+        <state_interface name="Present Position"/>
+        <state_interface name="Present Velocity"/>
+        <state_interface name="Present Current"/>
+        <param name="Drive Mode">4</param>
+        <param name="Velocity Limit">6486</param>
+        <param name="Acceleration Limit">8050</param>
+        <param name="Profile Velocity">6486</param>
+        <param name="Profile Acceleration">8050</param>
+        <param name="Return Delay Time">0</param>
+        <param name="Position P Gain">1583185</param>
+        <param name="Velocity P Gain">18184</param>
+        <param name="Velocity I Gain">1585331</param>
+        <param name="Operating Mode">3</param>
+        <param name="Profile Acceleration Time">20</param>
+        <param name="Profile Time">200</param>
+      </gpio>
+      <gpio name="dxl6">
+        <param name="type">dxl</param>
+        <param name="ID">6</param>
+        <command_interface name="Goal Position"/>
+        <state_interface name="Present Position"/>
+        <state_interface name="Present Velocity"/>
+        <state_interface name="Present Current"/>
+        <param name="Drive Mode">5</param>
+        <param name="Velocity Limit">6486</param>
+        <param name="Acceleration Limit">8050</param>
+        <param name="Profile Velocity">6486</param>
+        <param name="Profile Acceleration">8050</param>
+        <param name="Return Delay Time">0</param>
+        <param name="Position P Gain">1583185</param>
+        <param name="Velocity P Gain">18184</param>
+        <param name="Velocity I Gain">1585331</param>
+        <param name="Operating Mode">3</param>
+        <param name="Profile Acceleration Time">20</param>
+        <param name="Profile Time">200</param>
+      </gpio>
+      <gpio name="omy_hat">
+        <param name="type">controller</param>
+        <param name="ID">200</param>
+        <param name="Power Enable">1</param>
+        <param name="Voltage Control Enable">1</param>
+        <param name="R LED">200</param>
+        <param name="G LED">200</param>
+        <param name="B LED">120</param>
+        <param name="Baud Rate (Bus)">8</param>
+        <param name="DXL Baud Rate">8</param>
+        <param name="Status">0</param>
+      </gpio>
+
+    </ros2_control>
+  </xacro:macro>
+</robot>

--- a/open_manipulator_description/urdf/omx/omx.urdf.xacro
+++ b/open_manipulator_description/urdf/omx/omx.urdf.xacro
@@ -5,12 +5,13 @@
   <xacro:arg name="use_fake_hardware" default="false" />
   <xacro:arg name="fake_sensor_commands" default="false" />
   <xacro:arg name="port_name" default="/dev/ttyUSB0" />
+  <xacro:arg name="ros2_control_type" default="omx" />
 
   <xacro:include filename="$(find open_manipulator_description)/gazebo/omx.gazebo.xacro" />
 
   <xacro:include filename="$(find open_manipulator_description)/urdf/omx/omx_arm.urdf.xacro" />
 
-  <xacro:include filename="$(find open_manipulator_description)/ros2_control/omx.ros2_control.xacro" />
+  <xacro:include filename="$(find open_manipulator_description)/ros2_control/$(arg ros2_control_type).ros2_control.xacro" />
 
   <link name="world"/>
 

--- a/open_manipulator_description/urdf/omy_3m/omy_3m.urdf.xacro
+++ b/open_manipulator_description/urdf/omy_3m/omy_3m.urdf.xacro
@@ -4,12 +4,13 @@
   <xacro:arg name="use_sim" default="false" />
   <xacro:arg name="use_fake_hardware" default="false" />
   <xacro:arg name="fake_sensor_commands" default="false" />
+  <xacro:arg name="ros2_control_type" default="omy_3m" />
 
   <xacro:include filename="$(find open_manipulator_description)/urdf/omy_3m/omy_3m_arm.urdf.xacro" />
 
   <xacro:include filename="$(find open_manipulator_description)/gazebo/omy_3m.gazebo.xacro" />
 
-  <xacro:include filename="$(find open_manipulator_description)/ros2_control/omy_3m.ros2_control.xacro" />
+  <xacro:include filename="$(find open_manipulator_description)/ros2_control/$(arg ros2_control_type).ros2_control.xacro" />
 
   <xacro:include filename="$(find open_manipulator_description)/ros2_control/omy_3m_end_unit.ros2_control.xacro" />
 

--- a/open_manipulator_description/urdf/omy_f3m/omy_f3m.urdf.xacro
+++ b/open_manipulator_description/urdf/omy_f3m/omy_f3m.urdf.xacro
@@ -5,6 +5,7 @@
   <xacro:arg name="use_fake_hardware" default="false" />
   <xacro:arg name="fake_sensor_commands" default="false" />
   <xacro:arg name="config_type" default="omy_f3m" />
+  <xacro:arg name="ros2_control_type" default="omy_f3m" />
 
   <xacro:include filename="$(find open_manipulator_description)/urdf/omy_f3m/omy_f3m_arm.urdf.xacro" />
 
@@ -14,7 +15,7 @@
 
   <xacro:include filename="$(find open_manipulator_description)/gazebo/rh_p12_rn_a.gazebo.xacro" />
 
-  <xacro:include filename="$(find open_manipulator_description)/ros2_control/omy_f3m.ros2_control.xacro" />
+  <xacro:include filename="$(find open_manipulator_description)/ros2_control/$(arg ros2_control_type).ros2_control.xacro" />
 
   <xacro:include filename="$(find open_manipulator_description)/ros2_control/omy_f3m_end_unit.ros2_control.xacro" />
 

--- a/open_manipulator_description/urdf/omy_l100/omy_l100.urdf.xacro
+++ b/open_manipulator_description/urdf/omy_l100/omy_l100.urdf.xacro
@@ -5,12 +5,13 @@
   <xacro:arg name="use_fake_hardware" default="false" />
   <xacro:arg name="fake_sensor_commands" default="false" />
   <xacro:arg name="port_name" default="/dev/ttyUSB0" />
+  <xacro:arg name="ros2_control_type" default="omy_l100" />
 
   <xacro:include filename="$(find open_manipulator_description)/urdf/omy_l100/omy_l100_arm.urdf" />
 
   <xacro:include filename="$(find open_manipulator_description)/gazebo/omy_l100.gazebo.xacro" />
 
-  <xacro:include filename="$(find open_manipulator_description)/ros2_control/omy_l100.ros2_control.xacro" />
+  <xacro:include filename="$(find open_manipulator_description)/ros2_control/$(arg ros2_control_type).ros2_control.xacro" />
 
   <link name="world"/>
 


### PR DESCRIPTION
**Support Time-based Profile as Default Configuration for OMY**

* Enabled **time-based profile** as the default profile generation method for Dynamixel Y in OMY.
* Added a new `ros2_control` configuration file for **OMY\_F3M**, intended for **imitation learning inference**.

This configuration can be launched using the following command:

```bash
ros2 launch open_manipulator_bringup omy_f3m_follower_ai.launch.py ros2_control_type:=omy_f3m_30hz
```
