### PR TITLE
Need to disable collisions between links 6 and 7 (both are gripper links) for MoveIt to find paths

### DIFF
--- a/open_manipulator_bringup/config/omx_f/initial_positions.yaml
+++ b/open_manipulator_bringup/config/omx_f/initial_positions.yaml
@@ -10,7 +10,7 @@ joint_trajectory_executor:
     step_names: [step1, step2]  # Names of the steps
 
     step1: [0.0, 0.0, 0.0, 0.0, 0.0]
-    step2: [0.0, -1.57, 1.57, 1.57, 0.0]
+    step2: [0.0, -0.785, -0.785, 0.0, 0.0]
 
     duration: 5.0
     epsilon: 0.15

--- a/open_manipulator_moveit_config/config/omx_f/omx_f.srdf
+++ b/open_manipulator_moveit_config/config/omx_f/omx_f.srdf
@@ -57,5 +57,5 @@
     <disable_collisions link1="link4" link2="link5" reason="Adjacent"/>
     <disable_collisions link1="link5" link2="link6" reason="Adjacent"/>
     <disable_collisions link1="link5" link2="link7" reason="Adjacent"/>
-    <disable_collisions link1="link6" link2="link7" reason="Adjacent"/>
+    <disable_collisions link1="link6" link2="link7" reason="Never"/>
 </robot>

--- a/open_manipulator_moveit_config/config/omx_f/omx_f.srdf
+++ b/open_manipulator_moveit_config/config/omx_f/omx_f.srdf
@@ -24,17 +24,17 @@
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="init" group="arm">
         <joint name="joint1" value="0"/>
-        <joint name="joint2" value="0.0"/>
+        <joint name="joint2" value="0"/>
         <joint name="joint3" value="0"/>
         <joint name="joint4" value="0"/>
         <joint name="joint5" value="0"/>
     </group_state>
     <group_state name="home" group="arm">
         <joint name="joint1" value="0"/>
-        <joint name="joint2" value="1.57"/>
-        <joint name="joint3" value="0.0"/>
-        <joint name="joint4" value="0.0"/>
-        <joint name="joint5" value="0.0"/>
+        <joint name="joint2" value="-1.57"/>
+        <joint name="joint3" value="1.57"/>
+        <joint name="joint4" value="1.57"/>
+        <joint name="joint5" value="0"/>
     </group_state>
     <group_state name="close" group="gripper">
         <joint name="gripper_joint_1" value="0"/>

--- a/open_manipulator_moveit_config/config/omx_f/omx_f.srdf
+++ b/open_manipulator_moveit_config/config/omx_f/omx_f.srdf
@@ -24,17 +24,17 @@
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="init" group="arm">
         <joint name="joint1" value="0"/>
-        <joint name="joint2" value="0"/>
+        <joint name="joint2" value="0.0"/>
         <joint name="joint3" value="0"/>
         <joint name="joint4" value="0"/>
         <joint name="joint5" value="0"/>
     </group_state>
     <group_state name="home" group="arm">
         <joint name="joint1" value="0"/>
-        <joint name="joint2" value="-1.57"/>
-        <joint name="joint3" value="1.57"/>
-        <joint name="joint4" value="1.57"/>
-        <joint name="joint5" value="0"/>
+        <joint name="joint2" value="1.57"/>
+        <joint name="joint3" value="0.0"/>
+        <joint name="joint4" value="0.0"/>
+        <joint name="joint5" value="0.0"/>
     </group_state>
     <group_state name="close" group="gripper">
         <joint name="gripper_joint_1" value="0"/>
@@ -57,4 +57,5 @@
     <disable_collisions link1="link4" link2="link5" reason="Adjacent"/>
     <disable_collisions link1="link5" link2="link6" reason="Adjacent"/>
     <disable_collisions link1="link5" link2="link7" reason="Adjacent"/>
+    <disable_collisions link1="link6" link2="link7" reason="Adjacent"/>
 </robot>

--- a/open_manipulator_moveit_config/launch/omx_f_moveit.launch.py
+++ b/open_manipulator_moveit_config/launch/omx_f_moveit.launch.py
@@ -77,16 +77,19 @@ def generate_launch_description():
         'warehouse_host': warehouse_sqlite_path,
     }
 
+    moveit_params = moveit_config.to_dict()
+    moveit_params['publish_robot_description'] = False
     move_group_node = Node(
         package='moveit_ros_move_group',
         executable='move_group',
         output='screen',
         parameters=[
-            moveit_config.to_dict(),
+            moveit_params,
             warehouse_ros_config,
             {
                 'use_sim_time': use_sim,
                 'publish_robot_description_semantic': publish_robot_description_semantic,
+                'publish_robot_description': False,  # bringup handles this
             },
         ],
     )
@@ -102,7 +105,6 @@ def generate_launch_description():
         output='log',
         arguments=['-d', rviz_config_file],
         parameters=[
-            moveit_config.robot_description,
             moveit_config.robot_description_semantic,
             moveit_config.robot_description_kinematics,
             moveit_config.planning_pipelines,


### PR DESCRIPTION
After launching `ros2 launch open_manipulator_bringup omx_f.launch.py` and `ros2 launch open_manipulator_bringup omx_f.launch.py` I couldn't plan any paths due to collision between links 6 and 7. Because these are gripper links, I think we can disable collision between them. When I made that change, I could plan and execute paths.