### PR TITLE
omx_moveit srdf file modification

### DIFF
--- a/open_manipulator_moveit_config/config/omx_f/omx_f.srdf
+++ b/open_manipulator_moveit_config/config/omx_f/omx_f.srdf
@@ -57,6 +57,6 @@
     <disable_collisions link1="link4" link2="link5" reason="Adjacent"/>
     <disable_collisions link1="link5" link2="link6" reason="Adjacent"/>
     <disable_collisions link1="link5" link2="link7" reason="Adjacent"/>
-    <disable_collisions link1="link6" link2="link7" reason="Adjacent"/>
+    <disable_collisions link1="link6" link2="link7" reason="Always"/>
 
 </robot>

--- a/open_manipulator_moveit_config/config/omx_f/omx_f.srdf
+++ b/open_manipulator_moveit_config/config/omx_f/omx_f.srdf
@@ -57,4 +57,6 @@
     <disable_collisions link1="link4" link2="link5" reason="Adjacent"/>
     <disable_collisions link1="link5" link2="link6" reason="Adjacent"/>
     <disable_collisions link1="link5" link2="link7" reason="Adjacent"/>
+    <disable_collisions link1="link6" link2="link7" reason="Adjacent"/>
+
 </robot>


### PR DESCRIPTION
This change updates the MoveIt configuration to resolve a self-collision issue between the gripper links. The detected collision was preventing MoveIt from planning valid paths, so collision checking between these links has been disabled.
