### PR TITLE
Fit OMY-F3M collision primitives to the link meshes

### DIFF
--- a/open_manipulator_description/urdf/omy_f3m/omy_f3m.urdf.xacro
+++ b/open_manipulator_description/urdf/omy_f3m/omy_f3m.urdf.xacro
@@ -40,17 +40,12 @@
     <origin xyz="0 -0.141 0" rpy="0 0 0"/>
   </joint>
 
-  <link name="$(arg prefix)end_effector_link">
-    <visual>
-      <origin xyz="0 0 0" rpy="0 0 0"/>
-      <geometry>
-        <box size="0.01 0.01 0.01" />
-      </geometry>
-      <material name="red">
-        <color rgba="1.0 0.0 0.0 1"/>
-      </material>
-    </visual>
-  </link>
+  <!--
+    Tool centre point: a frame, so no geometry. Do not give it collision
+    geometry to silence MoveIt's visual-without-collision warning - it
+    sits between the fingers and would collide with whatever is grasped.
+  -->
+  <link name="$(arg prefix)end_effector_link"/>
 
   <xacro:omy_f3m prefix="$(arg prefix)" />
   <xacro:omy_f3m_gazebo prefix="$(arg prefix)" />

--- a/open_manipulator_description/urdf/omy_f3m/omy_f3m_arm.urdf.xacro
+++ b/open_manipulator_description/urdf/omy_f3m/omy_f3m_arm.urdf.xacro
@@ -15,10 +15,27 @@
                <color rgba="0.2 0.2 0.2 1" />
             </material>
          </visual>
+         <!-- Bottom face held 0.2 mm above the mounting plane instead of
+              carrying the margin below it, so a mount modelled flush with
+              z=0 does not read as a collision. FCL collides at any negative
+              separation and not at zero, so sitting on the plane exactly
+              would leave the result to rounding. -->
          <collision>
-            <origin xyz="0 0 0.03" rpy="0 0 0" />
+            <origin xyz="0.0000 0.0000 0.0039" rpy="0.0000 -0.0000 0.0000" />
             <geometry>
-               <cylinder radius="0.08" length="0.05"/>
+               <box size="0.1710 0.1710 0.0074"/>
+            </geometry>
+         </collision>
+         <collision>
+            <origin xyz="-0.0040 0.0000 0.0475" rpy="0.0000 -0.0000 0.0000" />
+            <geometry>
+               <box size="0.1490 0.1410 0.0798"/>
+            </geometry>
+         </collision>
+         <collision>
+            <origin xyz="0.0000 0.0000 0.1010" rpy="0.0000 -0.0000 0.0000" />
+            <geometry>
+               <cylinder radius="0.0446" length="0.0271"/>
             </geometry>
          </collision>
          <inertial>
@@ -46,9 +63,29 @@
             </material>
          </visual>
          <collision>
-            <origin xyz="0 -0.01 -0.035" rpy="0 0 0" />
+            <origin xyz="0.0000 -0.0553 0.0000" rpy="-1.5708 -0.0000 0.0000" />
             <geometry>
-               <cylinder radius="0.055" length="0.1"/>
+               <cylinder radius="0.0440" length="0.0184"/>
+            </geometry>
+         </collision>
+         <!-- Two overlapping boxes = one box chamfered on the -x and
+              +x corners, which URDF cannot express directly. -->
+         <collision>
+            <origin xyz="0.0000 -0.0085 0.0016" rpy="-1.5708 -0.0000 0.0000" />
+            <geometry>
+               <box size="0.0780 0.1281 0.0753"/>
+            </geometry>
+         </collision>
+         <collision>
+            <origin xyz="0.0000 -0.0085 -0.0004" rpy="-1.5708 -0.0000 0.0000" />
+            <geometry>
+               <box size="0.0880 0.1241 0.0753"/>
+            </geometry>
+         </collision>
+         <collision>
+            <origin xyz="-0.0000 0.0366 -0.0036" rpy="1.5708 0.0000 3.1416" />
+            <geometry>
+               <box size="0.0655 0.1178 0.0148"/>
             </geometry>
          </collision>
          <inertial>
@@ -76,9 +113,21 @@
             </material>
          </visual>
          <collision>
-            <origin xyz="-0.005 -0.02 0.13" rpy="0 0 0" />
+            <origin xyz="0.0000 -0.0016 0.0001" rpy="0.0000 -0.0000 0.0000" />
             <geometry>
-               <cylinder radius="0.046" length="0.28"/>
+               <box size="0.0880 0.1281 0.0882"/>
+            </geometry>
+         </collision>
+         <collision>
+            <origin xyz="0.0000 0.0000 0.1210" rpy="0.0000 -0.0000 0.0000" />
+            <geometry>
+               <cylinder radius="0.0390" length="0.1535"/>
+            </geometry>
+         </collision>
+         <collision>
+            <origin xyz="-0.0000 0.0033 0.2419" rpy="0.0000 -0.0000 1.5708" />
+            <geometry>
+               <box size="0.1184 0.0780 0.0882"/>
             </geometry>
          </collision>
          <inertial>
@@ -106,9 +155,21 @@
             </material>
          </visual>
          <collision>
-            <origin xyz="0 0.125 0.08" rpy="0 0 0" />
+            <origin xyz="0.0000 0.1098 0.0057" rpy="0.0000 -0.0000 0.0000" />
             <geometry>
-               <cylinder radius="0.042" length="0.17"/>
+               <box size="0.0780 0.1065 0.0894"/>
+            </geometry>
+         </collision>
+         <collision>
+            <origin xyz="0.0000 0.1240 0.1147" rpy="0.0000 -0.0000 0.0000" />
+            <geometry>
+               <cylinder radius="0.0390" length="0.1285"/>
+            </geometry>
+         </collision>
+         <collision>
+            <origin xyz="0.0000 0.1207 0.2187" rpy="0.0000 -0.0000 0.0000" />
+            <geometry>
+               <box size="0.0780 0.1184 0.0796"/>
             </geometry>
          </collision>
          <inertial>
@@ -136,9 +197,21 @@
             </material>
          </visual>
          <collision>
-            <origin xyz="0 0 0" rpy="1.57 0 0" />
+            <origin xyz="-0.0000 -0.1453 0.0077" rpy="-1.5708 -0.0000 0.0000" />
             <geometry>
-               <cylinder radius="0.045" length="0.10"/>
+               <box size="0.0585 0.1095 0.0134"/>
+            </geometry>
+         </collision>
+         <collision>
+            <origin xyz="0.0000 -0.1062 0.0033" rpy="-1.5708 -0.0000 0.0000" />
+            <geometry>
+               <box size="0.0780 0.1184 0.0647"/>
+            </geometry>
+         </collision>
+         <collision>
+            <origin xyz="0.0000 -0.0639 0.0000" rpy="-1.5708 -0.0000 0.0000" />
+            <geometry>
+               <cylinder radius="0.0390" length="0.0199"/>
             </geometry>
          </collision>
          <inertial>
@@ -166,9 +239,21 @@
             </material>
          </visual>
          <collision>
-            <origin xyz="0 0.01 0.005" rpy="0 0 0" />
+            <origin xyz="0.0000 0.0000 0.0664" rpy="0.0000 -0.0000 0.0000" />
             <geometry>
-               <cylinder radius="0.043" length="0.05"/>
+               <cylinder radius="0.0390" length="0.0199"/>
+            </geometry>
+         </collision>
+         <collision>
+            <origin xyz="0.0000 -0.0033 0.1087" rpy="0.0000 -0.0000 0.0000" />
+            <geometry>
+               <box size="0.0780 0.1184 0.0647"/>
+            </geometry>
+         </collision>
+         <collision>
+            <origin xyz="0.0000 -0.0077 0.1478" rpy="0.0000 -0.0000 0.0000" />
+            <geometry>
+               <box size="0.0585 0.1095 0.0134"/>
             </geometry>
          </collision>
          <inertial>
@@ -196,9 +281,21 @@
             </material>
          </visual>
          <collision>
-            <origin xyz="0 -0.1 0" rpy="1.57 0 0" />
+            <origin xyz="-0.0024 -0.0800 -0.0071" rpy="0.0000 -0.0000 0.0000" />
             <geometry>
-               <cylinder radius="0.08" length="0.22"/>
+               <box size="0.0808 0.0470 0.0618"/>
+            </geometry>
+         </collision>
+         <collision>
+            <origin xyz="-0.0000 -0.0828 0.0309" rpy="0.0000 -0.0000 0.0000" />
+            <geometry>
+               <box size="0.0589 0.0415 0.0142"/>
+            </geometry>
+         </collision>
+         <collision>
+            <origin xyz="0.0000 -0.0758 0.0712" rpy="0.0000 -0.0000 0.0000" />
+            <geometry>
+               <box size="0.0490 0.0285 0.0665"/>
             </geometry>
          </collision>
          <inertial>
@@ -226,9 +323,21 @@
             </material>
          </visual>
          <collision>
-            <origin xyz="0 0.03 0.04" rpy="0 0 0" />
+            <origin xyz="-0.0195 -0.0058 0.0000" rpy="1.5708 -0.0000 1.5708" />
             <geometry>
-               <cylinder radius="0.035" length="0.12"/>
+               <box size="0.0125 0.0430 0.0101"/>
+            </geometry>
+         </collision>
+         <collision>
+            <origin xyz="0.0000 -0.0013 0.0000" rpy="1.5708 -0.0000 1.5708" />
+            <geometry>
+               <box size="0.0035 0.0430 0.0288"/>
+            </geometry>
+         </collision>
+         <collision>
+            <origin xyz="0.0195 -0.0058 0.0000" rpy="1.5708 -0.0000 1.5708" />
+            <geometry>
+               <box size="0.0125 0.0430 0.0101"/>
             </geometry>
          </collision>
          <inertial>


### PR DESCRIPTION
Each OMY-F3M arm link is covered by a single hand-placed cylinder. Sampled
against the link meshes in this repository, those cylinders leave **47% of the
arm's surface outside any collision volume** — link4 and link5 have no part of
their surface covered at all, and a point on a link can sit up to 127 mm
outside its own primitive — while inflating link6 and the flange to 12x and
30x their true volume.

The planner therefore misses real contacts around the elbow and invents
phantom ones around the gripper: the arm both clips itself and refuses plans
that are physically fine.

## What changed

- Every arm link is now covered by up to three primitives fitted to its own
  mesh — **25 in total, replacing 8** — enclosing each mesh with a 0.5 mm
  margin in **8% less total volume** than the stock cylinders (9707 cm³
  against 10571 cm³).
- `link1` is chamfered by hand, expressed as two overlapping boxes. The link
  is a concave yoke, so its convex cover clipped link3 by 1.2 mm in folded
  poses that the real links clear by about 9 mm. Only the two corners the arms
  fold into are given up, and they lie inside the yoke's opening where the
  link has no material, so no coverage is lost. The escape is 0.024 mm.
- `link0`'s base-plate box stops **0.2 mm above** the mounting plane instead
  of carrying the 0.5 mm margin below it, so a table or stand modelled at
  z = 0 does not read as a permanent collision. Not flush with the plane: FCL
  reports a collision at *any* negative separation — measured down to
  1e-16 m — and none at exactly zero, so a box resting on the plane would
  leave the answer to rounding in the transform chain: the mount's pose, its
  mesh vertices, any quaternion between them. The cost is the plate's
  underside, 0.87% of the arm's surface, sitting 0.2 mm outside its cover.
  Nothing can occupy that space, because the face is bolted to the mount. The
  stock cylinder hid all of this by starting 5 mm *above* the mounting face —
  which also meant it never modelled the base plate at all.
- Second commit, independent of the geometry: `end_effector_link` loses its
  1 cm marker box and becomes a pure TF frame. That box is its only geometry,
  so MoveIt warns on every load that the link has visual but no collision
  geometry. Giving it collision geometry would be the wrong fix — the frame
  sits between the gripper fingers, so a solid box there would collide with
  whatever the gripper reaches for. An RViz TF or Axes display shows the frame
  without putting geometry in the planning scene. **Drop that commit if you
  want to keep the marker.**

Visual meshes, joints, limits and inertials are untouched. This is collision
geometry only.

## Validation

Mesh enclosure, all eight arm meshes in this repository:

| | surface outside its cover | worst escape | total volume |
|---|---|---|---|
| stock cylinders | 46.97% | 126.9 mm | 10571 cm³ |
| fitted primitives | 0.89% | 0.2 mm | 9707 cm³ |

Both figures for the fitted primitives are the two deliberate exceptions
above, and nothing else: 0.87% of the surface and the full 0.2 mm are the
underside of the base plate held clear of the mounting plane, and the
remaining 0.02% / 0.024 mm is link1's chamfer. Every other mesh is enclosed.

Self-collision, 300 random configurations × the 18 link pairs the SRDF does
not disable, each pair judged against the meshes themselves:

| | real contacts found | real contacts **missed** | false positives |
|---|---|---|---|
| stock cylinders | 108 / 220 | **112** | 393 |
| fitted primitives | 220 / 220 | **0** | 310 |

The stock model misses **51% of real self-collisions.** The fitted model
misses none.

Both models still report false positives, because no convex cover of a
concave link can avoid them — but they differ in kind. The fitted model's are
near-misses: median true clearance 9.5 mm, none beyond 42 mm. The stock
model's have a median clearance of 32 mm, and about a quarter of them are
between links more than 20 mm apart.

Both named poses in `open_manipulator_moveit_config` (`init` and `home`) are
collision-free before and after.

**The `disable_collisions` list in `open_manipulator_moveit_config` needs no
change.** Regenerating it against the fitted geometry yields exactly the 12
adjacent and 28 never-touching pairs `omy_f3m.srdf` already ships, with
nothing disabled for overlapping at rest.

Worth noting what the stock geometry does to that list. With the stock
cylinders, link6's collision volume permanently swallows all five gripper
links — `rh_p12_rn_base`, `r1`, `r2`, `l1`, `l2` all sit inside it at every
pose — so those five pairs are only "Never" in the SRDF because they were
never actually testable. With the fitted geometry all five come clear, and the
one arm-to-gripper overlap that remains is `end_effector_flange_link` against
`rh_p12_rn_base`, which is the real adjacency the gripper bolts onto and is
already disabled as "Adjacent".

## Pre-existing issue this change surfaces, unrelated to the geometry

Once the D405 is in the model, `omy_f3m.urdf.xacro` has permanent
self-collisions that `omy_f3m.srdf` does not disable. On current `main` there
are two — `camera_link`/`link6` and `camera_link`/`end_effector_flange_link`.
The refit removes the second one (the stock flange cylinder is 462 cm³ against
the flange's true 15 cm³, so it swallows the camera), but `camera_link`/`link6`
remains: the camera body sits inside the volume `link6.stl` occupies, so no
cover of that mesh can avoid it.

This predates this PR and I have not touched the SRDF, since how you want it
fixed is your call — one line in `omy_f3m.srdf`:

```xml
<disable_collisions link1="camera_link" link2="link6" reason="Adjacent"/>
```

or dropping the camera's collision box, or trimming the camera volume out of
`link6.stl`. Happy to add whichever you prefer to this PR or send it
separately.

## Provenance

This geometry was fitted and is in production use in a dual-arm OMY-F3M cell,
where `open_manipulator_description` is a dependency. The numbers above were
all recomputed from scratch against this repository's `main`, including
`link6.stl`, which differs from the copy the fit was originally made against —
the fitted primitives enclose both versions with zero escape.

Commits are signed off per `CONTRIBUTING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

